### PR TITLE
Migliorato il cronjob, separazione giornaliero/settimanale

### DIFF
--- a/cronjob.php
+++ b/cronjob.php
@@ -2,21 +2,20 @@
 
 /*
  * ©2013 Croce Rossa Italiana
+ * CRONJOB - Esegue le operazioni pianificate,
+ * Giornaliere e settimanali
  */
 
 require './core.inc.php';
-
-/*
- * Rimuove limiti di tempo
- */
 set_time_limit(0);
 
 /*
- * Controllo di sicurezza, ho lanciato il cronjob troppo spesso?
+ * ====== SICUREZZA ======
+ * Evita lancio cronjob troppo frequente
  */
 $limite = 3600 * 23; // 23 ore
 $ora 	= (int) time(); $leggibile = date('d-m-Y H:i:s');
-$ultimo = (int) @file_get_contents('upload/log/cronjob.timestamp');
+$ultimo = (int) @file_get_contents('upload/log/cronjob.giornaliero.timestamp');
 if ( $ultimo && ($ora - $ultimo) < $limite ) {
      // 1. Memorizza tentativo negato nel log
      file_put_contents('upload/log/cronjob.log',
@@ -31,132 +30,133 @@ if ( $ultimo && ($ora - $ultimo) < $limite ) {
          "L'incidente verrà segnalato.");
 }
 // Aggiorna il timestamp dell'ultima esecuzione
-file_put_contents('upload/log/cronjob.timestamp', $ora);
+file_put_contents('upload/log/cronjob.giornaliero.timestamp', $ora);
+// Controlla se sia il caso di eseguire il settimanale...
+$limite = (3600 * 24 * 7) - 3600; // 7 giorni meno un'ora
+$settimanale = (int) @file_get_contents('upload/log/cronjob.settimanale.timestamp');
+if ( !$settimanale || ($ora - $ultime) > $limite ) {
+    $logS .= "[!] ESECUZIONE SETTIMANALE PROGRAMMATA (son passati 7 giorni)\n";
+    $settimanale = true;
+} else {
+    $logS = '';
+    $settimanale = false;
+}
 
+/*
+ * ====== AVVIO DEL CRONJOB ======
+ */
 $start = microtime(true);
+$log = date('d-m-Y H:i:s') . " CRONJOB INIZIATO\n{$logS}";
 
-/* Sessione di cronjob */
-$log = "Cronjob iniziato: " . date('d-m-Y H:i:s') . "\n";
 
-/* Le patenti in scadenza tra qui e 15 gg */
-$patenti = TitoloPersonale::inScadenza(2700, 2709, 15); // Minimo id titolo, Massimo id titolo, Giorni
+// =========== INIZIO CRONJOB GIORNALIERO
+function cronjobGiornaliero()  {
+    global $log, $db;
 
-$n = 0;
-
-/* Contiene gli id dei volontari già insuttati */
-$giaInsultati = [];
-
-foreach ( $patenti as $patente ) {
-   
-    $_v = $patente->volontario();
-    
-    /* Se l'ho già insultato... */
-    if ( in_array($_v->id, $giaInsultati ) ) {
-        continue; // Il prossimo...
+    /* === 1. CANCELLA FILE SCADUTI DA DISCO E DATABASE */
+    $n = 0;
+    foreach ( File::scaduti() as $f ) {
+        $f->cancella(); $n++;
     }
-    
-    /* Ricordati che l'ho insuttato */
-    $giaInsultati[] = $_v->id;
-    
-    $m = new Email('patenteScadenza', 'Avviso patente CRI in scadenza');
-    $m->a           = $_v;
-    $m->_NOME       = $_v->nome;
-    $m->_SCADENZA   = date('d-m-Y', $patente->fine);
-    $m->invia();
-    $n++;
-}
+    $log .= "Cancellati $n file scaduti\n";
 
-$log .= "Inviate $n notifiche di scadenza patente\n";
 
-/* Patenti civili in scadenza da qui a 15 giorni*/
-$patenti = TitoloPersonale::inScadenza(70, 77, 15); // Minimo id titolo, Massimo id titolo, Giorni
-$n = 0;
-
-/* Contiene gli id dei volontari già insuttati */
-$giaInsultati = [];
-foreach ( $patenti as $patente ) {
-    $_v = $patente->volontario();
-
-    /* Se l'ho già insultato... */
-    if ( in_array($_v->id, $giaInsultati ) ) {
-        continue; // Il prossimo...
+    /* === 2. CANCELLA SESSIONI SCADUTE DA DATABASE */
+    $n = 0;
+    foreach ( Sessione::scadute() as $s ) {
+        $s->cancella(); $n++;
     }
-
-    /* Ricordati che l'ho insuttato */
-    $giaInsultati[] = $_v->id;
-    $m = new Email('patenteScadenzaCivile', 'Avviso patente Civile in scadenza');
-    $m->a = $_v;
-    $m->_NOME = $_v->nome;
-    $m->_SCADENZA = date('d-m-Y', $patente->fine);
-    $m->invia();
-    $n++;
-}
-
-$log .= "Inviate $n notifiche di scadenza patente civili\n";
-
-/* Cancella i file scaduti da disco e database */
-$n = 0;
-foreach ( File::scaduti() as $f ) {
-    $f->cancella(); $n++;
-}
-$log .= "Cancellati $n file scaduti\n";
+    $log .= "Cancellate $n sessioni scadute\n";
 
 
-/* Cancella le sessioni scadute */
-$n = 0;
-foreach ( Sessione::scadute() as $s ) {
-    $s->cancella(); $n++;
-}
-$log .= "Cancellate $n sessioni scadute\n";
+};
+// =========== FINE CRONJOB GIORNALIERO
 
 
-/*
- * PRESIDENTE COMITATO
- * - Titoli pendenti
- * - App. pendenti
- */
-$n = 0;
-/*
- * Per ogni comitato iscritto a Gaia
- */
-foreach ( Comitato::elenco() as $comitato ) {
-    
-    /*
-     * Controlla appartenenze e titoli
-     */
-    $a = count($comitato->appartenenzePendenti());
-    $b = count($comitato->titoliPendenti());
-    
-    $c = $a + $b;
-    if ( $c == 0 ) { continue; }
-    
-    /*
-     * Per ogni presidente...
-     */
-    foreach ( $comitato->volontariPresidenti() as $presidente ) {
-        $m = new Email('riepilogoPresidente', "Promemoria: Ci sono {$c} azioni in sospeso");
-        $m->a       = $presidente;
-        $m->_NOME       = $presidente->nomeCompleto();
-        $m->_COMITATO   = $comitato->nomeCompleto();
-        $m->_APPPENDENTI= $a;
-        $m->_TITPENDENTI= $b;
+// =========== INIZIO CRONJOB SETTIMANALE
+function cronjobSettimanale() {
+    global $log, $db;
+
+    /* === 1. PATENTI CRI IN SCADENZA */
+    /* Le patenti in scadenza tra qui e 15 gg */
+    $patenti = TitoloPersonale::inScadenza(2700, 2709, 15); // Minimo id titolo, Massimo id titolo, Giorni
+    $n = 0;
+    $giaInsultati = [];
+    foreach ( $patenti as $patente ) {
+        $_v = $patente->volontario();
+        if ( in_array($_v->id, $giaInsultati ) ) {
+            continue; // Il prossimo...
+        }
+        $giaInsultati[] = $_v->id;
+        $m = new Email('patenteScadenza', 'Avviso patente CRI in scadenza');
+        $m->a           = $_v;
+        $m->_NOME       = $_v->nome;
+        $m->_SCADENZA   = date('d-m-Y', $patente->fine);
         $m->invia();
         $n++;
     }
-}
-$log .= "Inviati $n promemoria ai presidenti\n";
+    $log .= "Inviate $n notifiche di scadenza patente\n";
 
+    /* === 2. PATENTI CRI IN SCADENZA */
+    /* Patenti civili in scadenza da qui a 15 giorni*/
+    $patenti = TitoloPersonale::inScadenza(70, 77, 15); // Minimo id titolo, Massimo id titolo, Giorni
+    $n = 0;
+    $giaInsultati = [];
+    foreach ( $patenti as $patente ) {
+        $_v = $patente->volontario();
+        if ( in_array($_v->id, $giaInsultati ) ) {
+            continue; // Il prossimo...
+        }
+        $giaInsultati[] = $_v->id;
+        $m = new Email('patenteScadenzaCivile', 'Avviso patente Civile in scadenza');
+        $m->a = $_v;
+        $m->_NOME = $_v->nome;
+        $m->_SCADENZA = date('d-m-Y', $patente->fine);
+        $m->invia();
+        $n++;
+    }
+    $log .= "Inviate $n notifiche di scadenza patente civili\n";
+
+    /* === 3. RIEPILOGO PRESIDENTE */
+    $n = 0;
+    foreach ( Comitato::elenco() as $comitato ) {
+        $a = count($comitato->appartenenzePendenti());
+        $b = count($comitato->titoliPendenti());    
+        $c = $a + $b;
+        if ( $c == 0 ) { continue; }
+        foreach ( $comitato->volontariPresidenti() as $presidente ) {
+            $m = new Email('riepilogoPresidente', "Promemoria: Ci sono {$c} azioni in sospeso");
+            $m->a       = $presidente;
+            $m->_NOME       = $presidente->nomeCompleto();
+            $m->_COMITATO   = $comitato->nomeCompleto();
+            $m->_APPPENDENTI= $a;
+            $m->_TITPENDENTI= $b;
+            $m->invia();
+            $n++;
+        }
+    }
+    $log .= "Inviati $n promemoria ai presidenti\n";
+
+};
+// =========== FINE CRONJOB SETTIMANALE
+
+// Vera e propria esecuzione del cronjob...
+cronjobGiornaliero();
+if ( $settimanale ) {
+    cronjobSettimanale();
+    file_put_contents('upload/log/cronjob.settimanale.timestamp', $ora);
+}
 
 /* FINE CRONJOB */
 $end = microtime(true);
 $tempo = $end - $start;
-$log .= "Fine esecuzione ({$tempo} secondi)\n";
+$log .= "FINE (eseguito in {$tempo} secondi)\n";
 
 /* Stampa il log a video */
 echo "<pre>$log</pre>";
 
 /* Appende il file al log */
-file_put_contents('upload/log/cronjob.txt', "\n\n" . $log, FILE_APPEND);
+file_put_contents('upload/log/cronjob.txt', "\n" . $log, FILE_APPEND);
 
 /* Invia per email il log */
 $m = new Email('mailTestolibero', 'Report cronjob');


### PR DESCRIPTION
- Separazione codice giornaliero e settimanale
- Spostato in settimanale: riepologo presidente
- Spostato in settimanale: notifica patenti civili in scadenza
- Spostato in settimanale: notifica patenti CRI in scadenza
