### PR TITLE
Funzione Entita::id(); finalmente

### DIFF
--- a/core/class/Entita.class.php
+++ b/core/class/Entita.class.php
@@ -75,11 +75,33 @@ class Entita {
         }
     }
     
+    /**
+     * Ottiene un singolo elemento per un parametro univoco
+     * @param string $_nome Il nome del parametro
+     * @param string $_valore Il suo valore
+     * @return static|bool(false) Un elemento o false
+     */
     public static function by($_nome, $_valore) {
         $r = static::filtra([[$_nome, $_valore]], 'id LIMIT 0,1');
         if (!$r) { return false; }
         return $r[0];
     }
+
+    /**
+     * Ottiene un elemento per ID oppure lancia un'eccezione
+     * @param mixed $id L'ID univoco dell'oggetto
+     * @return static Un oggetto
+     * @throws Errore in caso di non esistente
+     */
+    public static function id($id = null) {
+        if ( $id === null ) {
+            // Non creero' un nuovo oggetto, ID mancante!
+            throw new Errore(1011);
+        }
+        return new static($id);
+    }
+
+
 
     /**
      * Dato hash della query e array di oggetti, salva in cache


### PR DESCRIPTION
``` php
Entita::id($id);
```
1. Piu' corto di `Entita::by('id', $id)`;
2. Evita la creazione di un oggetto, meglio di `new Entita($id)`;
3. Se non esiste l'oggetto lancia un'eccezione;
4. Se viene chiamato con `null` lancia un'eccezione;
