### PR TITLE
Modifica ordinamento Delegati

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,3 @@ upload/setup/autopull
 
 # Mantieni i placeholder
 !upload/avatar/placeholder/
-
-.settings/*
-.project


### PR DESCRIPTION
Modificato per selezionare i Delegati in ordine di obiettivo piuttosto che in ordine di inizio carica, piu comodo per consultazione.
