### PR TITLE
Fix issue544

### DIFF
--- a/core/class/Locale.class.php
+++ b/core/class/Locale.class.php
@@ -22,6 +22,15 @@ class Locale extends GeoPolitica {
         return $this->comitati();
     }
 
+    public function geoEstensione() {
+        $c = $this->comitati();
+        $r = [];
+        foreach ($c as $_c) {
+            $r[] = GeoPolitica::daOid($_c->oid());
+        }
+        return $r;
+    }
+
     public function figli() {
         return $this->comitati();
     }

--- a/core/class/Utente.class.php
+++ b/core/class/Utente.class.php
@@ -640,8 +640,11 @@ class Utente extends Persona {
         $d = $this->delegazioni($app);
         $c = [];
         foreach ( $d as $k ) {
-            // $c[] = $k->comitato();
-            $c = array_merge($k->estensione(), $c);
+            $comitato = $k->comitato();
+            $c[] = $comitato; 
+            if ($comitato->_estensione() < EST_PROVINCIALE) {
+                $c = array_merge($k->geoEstensione(), $c);
+            }
         }
         return array_unique($c);
     }
@@ -803,7 +806,7 @@ class Utente extends Persona {
     public function areeDiCompetenza( $c = null , $espandiLocale = false) {
         if ( $c ) {
             if ( $this->admin() || $this->presiede($c) ) {
-                return $c->aree();
+                return $c->aree(null, $espandiLocale);
             } elseif ( $o = $this->delegazioni(APP_OBIETTIVO, $c) ) {
                 $r = [];
                 foreach ( $o as $io ) {


### PR DESCRIPTION
Risolve una prima parte di #544 

Permette ai presidenti di creare attività del corretto livello dove ci sono delegati di obiettivo strategico nominati. Non permette ancora di creare attività sulle unità ai presidenti.

Quindi non ancora fix
