### PR TITLE
Amministratori possono cancellare comitati

### DIFF
--- a/inc/admin.comitati.php
+++ b/inc/admin.comitati.php
@@ -28,6 +28,11 @@ paginaAdmin();
             <i class="icon-warning-sign"></i> <strong>Comitati correlati</strong>.
             Attenzione il Comitato che si vuole cancellare ha dei comitati sottostanti, rimuoverli e riprovare.
         </div>
+<?php }elseif ( isset($_GET['evol']) ) { ?>
+        <div class="alert alert-error">
+            <i class="icon-warning-sign"></i> <strong>Volontari correlati</strong>.
+            Attenzione il Comitato che si vuole cancellare ha dei Volontari iscritti, rimuoverli e riprovare.
+        </div>
 <?php } ?>
 <script type="text/javascript"><?php require './js/presidente.utenti.js'; ?></script>
     <br/>

--- a/inc/admin.comitato.cancella.php
+++ b/inc/admin.comitato.cancella.php
@@ -11,5 +11,8 @@ $t = GeoPolitica::daOid($t);
 if($t->figli()){
 	redirect('admin.comitati&err');
 }
+if(Appartenenza::filtra([['comitato', $t]])){
+	redirect('admin.comitati&evol');
+}
 $t->cancella();
 redirect('admin.comitati&del');


### PR DESCRIPTION
- Possibilità degli amministratori di cancellare i comitati fix #572 
- Attenzione! Manca un controllo sugli eventuali volontari iscritti  tale comitato, verificare prima della cancellazione
