### PR TITLE
Se referente gruppo null permette caricamento altri gruppi

### DIFF
--- a/core/class/Gruppo.class.php
+++ b/core/class/Gruppo.class.php
@@ -11,6 +11,9 @@ class Gruppo extends Entita {
     }
     
     public function referente() {
+        if(!$this->referente){
+            return false;
+        }
         return Volontario::id($this->referente);
     }
     


### PR DESCRIPTION
In caso di campo referente null sul db prosegue e permette di individuare un nuovo referente del gruppo
