### PR TITLE
nuova versione del supporto con maggiori info #388

### DIFF
--- a/core/conf/mail/modelli/mailSupporto.html
+++ b/core/conf/mail/modelli/mailSupporto.html
@@ -1,2 +1,8 @@
 <p>_TESTO</p>
-<p><strong>Dati Volontario: </strong>_ID - _STATO - _NOME - _APP </p>
+<p><strong>Dati Volontario: </strong>
+<ul>
+<li>Id:           _ID </li>
+<li>Stato:        _STATO </li>
+<li>Nome:         _NOME<li>
+<li>Appartenenza: _APP<li> 
+</ul></p>

--- a/core/conf/mail/modelli/mailSupportoDaUfficio.html
+++ b/core/conf/mail/modelli/mailSupportoDaUfficio.html
@@ -1,0 +1,16 @@
+<p>_TESTO</p>
+<p><strong>Dati Volontario Richiedente: </strong>
+<ul>
+<li>Id:           _ID </li>
+<li>Stato:        _STATO </li>
+<li>Nome:         _NOME<li>
+<li>Appartenenza: _APP<li> 
+</ul></p>
+
+<p><strong>Dati Volontario per cui è richiesta l'assistenza: </strong>
+<ul>
+<li>Id:           _ID_V </li>
+<li>Stato:        _STATO_V </li>
+<li>Nome:         _NOME_V<li>
+<li>Appartenenza: _APP_V<li> 
+</ul></p>

--- a/inc/utente.mail.nuova.ok.php
+++ b/inc/utente.mail.nuova.ok.php
@@ -51,6 +51,38 @@ foreach($me->comitatiApp ([ APP_SOCI, APP_PRESIDENTE, APP_OBIETTIVO ]) as $elenc
     if (strlen($text) < 10) {
         redirect('utente.supporto&len');    
     }
+    //se ho un volontario per cui richiedere la cosa
+    if (isset($_POST['inputVolontario'])) {
+        //inserisco i dati del richiedente
+        $m = new Email('mailSupportoDaUfficio', 'Richiesta supporto: '.$oggetto);
+        $m->da = $me;
+        $m->_TESTO = $testo;
+        $m->_STATO = $conf['statoPersona'][$me->stato];
+        $m->_NOME = $me->nomeCompleto();
+        $m->_ID = $me->id;
+        $comitato = $me->unComitato();
+        if ($comitato) {
+            $comitato = $comitato->nomeCompleto();
+        } else {
+            $comitato = 'nessun comitato assegnato o volontario in attesa di conferma';
+        }
+        $m->_APP = $comitato;
+        //inserisco i dati del volontari per cui è richiesta assistenza
+        $u = Utente::id($_POST['inputVolontario']);
+        $m->_STATO = $conf['statoPersona'][$u->stato];
+        $m->_NOME = $u->nomeCompleto();
+        $m->_ID = $u->id;
+        $comitato = $u->unComitato();
+        if ($comitato) {
+            $comitato = $comitato->nomeCompleto();
+        } else {
+            $comitato = 'nessun comitato assegnato o volontario in attesa di conferma';
+        }
+        $m->_APP = $comitato;
+        
+        $m->invia();
+        redirect('utente.me&suppok');
+    }
 
     $m = new Email('mailSupporto', 'Richiesta supporto: '.$oggetto);
     $m->da = $me;
@@ -58,13 +90,15 @@ foreach($me->comitatiApp ([ APP_SOCI, APP_PRESIDENTE, APP_OBIETTIVO ]) as $elenc
     $m->_STATO = $conf['statoPersona'][$me->stato];
     $m->_NOME = $me->nomeCompleto();
     $m->_ID = $me->id;
-    $comitato = $me->unComitato();
-    if ($comitato) {
-        $comitato = $comitato->nomeCompleto();
+    if ($comitato = $me->unComitato()) {
+        $comitato = ''.$comitato->nomeCompleto().' - membro volontario';
+    } else if($comitato = $me->unComitato(MEMBRO_PENDENTE)) {
+        $comitato = ''.$comitato->nomeCompleto().' - membro pendente';
     } else {
         $comitato = 'nessun comitato assegnato';
     }
     $m->_APP = $comitato;
+
     $m->invia();
     redirect('utente.me&suppok');    
 

--- a/inc/utente.supporto.php
+++ b/inc/utente.supporto.php
@@ -4,6 +4,8 @@
  * ©2013 Croce Rossa Italiana
  */
 
+caricaSelettore();
+
 ?>
 <div class="row-fluid">
     <div class="span3">
@@ -27,6 +29,14 @@
             <p>Siamo qui per aiutare. Con questo modulo puoi richiedere supporto per Gaia.</p>
             <?php } ?>
         </div>
+        <?php if($me->delegazioni(APP_SOCI) || $me->delegazioni(APP_PRESIDENTE) || $me->admin()) { 
+          $assistiAltroVolontario = true; ?>
+        <div class="alert alert-block alert-info">
+            <h4><i class="icon-user"></i> Sei un Presidente o un responsabile Ufficio Soci?</h4>
+            <p>Puoi richiedere assistenza per un volontario di un tuo comitato. </p>
+            <p>Selezione un volontario tramite il pulsante qui sotto nel caso in cui tu voglia segnalare un'anomalia (codice fiscale errato, data di nascita errata, ecc) per noi sarà più facile risolvere il problema.</p>
+        </div>
+        <?php } ?>
            <form class="form-horizontal" action="?p=utente.mail.nuova.ok&supp" method="POST">
             <div class="control-group">
               <label class="control-label" for="inputDestinatario">Destinatario</label>
@@ -40,6 +50,17 @@
                 <input type="text" class="input-xxlarge" name="inputOggetto" autofocus id="inputOggetto" required placeholder="es.: Dubbio sul Curriculum">
               </div>
             </div>
+            <?php if($assistiAltroVolontario) { ?>
+            <div class="control-group">
+              <label class="control-label" for="inputOggetto">Assistenza per</label>
+              <div class="controls">
+              <a data-selettore="true" data-input="inputVolontario"
+                  class="btn btn-inverse btn-small">
+                  Seleziona un volontario... <i class="icon-pencil"></i>
+              </a>
+              </div>
+            </div>
+            <?php } ?>
             <div class="control-group">
             <label class="control-label" for="inputTesto">Testo</label>
             <div class="controls">


### PR DESCRIPTION
Due versioni di supporto:
- quando si richiede assistanza per se stessi il sistema indica se si è membri volontari, membri con appartenenza pendente o se non si hanno comitati
- quando si richiede assistenza per altre persone (solo us e presidenti) il sistema riporta i dati di entrambi

Questo porta a fix #388 
