### PR TITLE
Fix urgente sicurezza

### DIFF
--- a/core/inc/sicurezza.lib.php
+++ b/core/inc/sicurezza.lib.php
@@ -24,7 +24,7 @@ function proteggiDatiSensibili( $volontario, $app = [APP_PRESIDENTE] ) {
     global $me;
     if ( $me->admin() ) { return true; }
     $comitati = $me->comitatiApp($app);
-    $comitatiVolontario = $volontario->comitati(MEMBRO_DIMESSO);
+    $comitatiVolontario = $volontario->comitati(SOGLIA_APPARTENENZE);
     if ( !$comitatiVolontario ) { return true; }
     foreach ( $comitatiVolontario as $comitato ) {
         if (in_array($comitato, $comitati)) {


### PR DESCRIPTION
Modifica di `proteggiDatiSensibili()`, non ancora del tutto risolutiva:
- premette visione agli admin solo se in admin mode
- blinda visualizzazione da `SOGLIA_APPARTENENZA` in su

Manca da gestire in maniera più sensata le persone che non hanno appartenenze attuali. al momento viene fatto ciò:

``` php
$comitatiVolontario = $volontario->comitati(SOGLIA_APPARTENENZE);
if ( !$comitatiVolontario ) { return true; }
```

Bisognerebbe verificare l'ultima appartenenza e farla visualizzare alla struttura CRI corretta
