### PR TITLE
risolto problema volontari dimessi

### DIFF
--- a/core/inc/sicurezza.lib.php
+++ b/core/inc/sicurezza.lib.php
@@ -25,11 +25,20 @@ function proteggiDatiSensibili( $volontario, $app = [APP_PRESIDENTE] ) {
     if ( $me->admin() ) { return true; }
     $comitati = $me->comitatiApp($app);
     $comitatiVolontario = $volontario->comitati(SOGLIA_APPARTENENZE);
-    if ( !$comitatiVolontario ) { return true; }
-    foreach ( $comitatiVolontario as $comitato ) {
-        if (in_array($comitato, $comitati)) {
+    if ($comitatiVolontario) {
+        foreach ( $comitatiVolontario as $comitato ) {
+            if (in_array($comitato, $comitati)) {
+                return true;
+            }
+        }
+    }
+    $ultimoComitato = $volontario->ultimaAppartenenza(MEMBRO_DIMESSO);
+    if ($ultimoComitato) {
+        $ultimoComitato = $ultimoComitato->comitato();
+        if (in_array($ultimoComitato, $comitati)) {
             return true;
         }
     }
+
     redirect('errore.permessi&cattivo');
 }


### PR DESCRIPTION
Seconda parte del fix. Anche i volontari dimessi vengono visti solo da presidente e ufficio soci dell'ultimo comitato in cui sono stati.
