### PR TITLE
Riportare CF in caso di errore captcha fix #712

### DIFF
--- a/inc/riconoscimento.ok.php
+++ b/inc/riconoscimento.ok.php
@@ -2,6 +2,7 @@
 
 $codiceFiscale = $_POST['inputCodiceFiscale'];
 $codiceFiscale = maiuscolo($codiceFiscale);
+$sessione->codiceFiscale = $codiceFiscale;
 
 if ( !preg_match("/^[A-Z]{6}[0-9]{2}[A-Z][0-9]{2}[A-Z][0-9]{3}[A-Z]$/", $codiceFiscale) )
 	redirect('riconoscimento&e');

--- a/inc/riconoscimento.php
+++ b/inc/riconoscimento.php
@@ -76,7 +76,7 @@ if ( isset($_GET['tipo'] ) ) {
           <div class="control-group">
             <label class="control-label" for="inputCodiceFiscale">Cod. Fiscale</label>
             <div class="controls">
-              <input autofocus class="input-large" type="text" id="inputCodiceFiscale" name="inputCodiceFiscale" placeholder="16 caratteri alfanumerici" required  pattern="[A-Za-z]{6}[0-9]{2}[A-Za-z][0-9]{2}[A-Za-z][0-9]{3}[A-Za-z]" />
+              <input autofocus class="input-large" type="text" id="inputCodiceFiscale" name="inputCodiceFiscale" placeholder="16 caratteri alfanumerici" required  pattern="[A-Za-z]{6}[0-9]{2}[A-Za-z][0-9]{2}[A-Za-z][0-9]{3}[A-Za-z]" value="<?= $sessione->codiceFiscale; ?>" />
             </div>
           </div>
           


### PR DESCRIPTION
In caso di errato inserimento del captcha non è necessario reinserire il CF ma viene salvato in sessione e rivisualizzato all'utente che dovrà solo reinserire il captcha quindi fix #712
