### PR TITLE
Errore nella visualizzazione data fix #740

### DIFF
--- a/inc/presidente.estensione.ok.php
+++ b/inc/presidente.estensione.ok.php
@@ -28,7 +28,7 @@
         $m->a = $a->volontario();
         $m->_NOME       = $a->volontario()->nome;
         $m->_COMITATO   = $a->comitato()->nomeCompleto();
-        $m-> _TIME = date('d-m-Y', $e->protData);
+        $m-> _TIME = date('d-m-Y', $e->appartenenza()->timestamp);
         $m->invia();
       
         redirect('presidente.estensione&ok');  


### PR DESCRIPTION
La data di inoltro era relativa al protocollo ora corretta con la data di inoltro richeista da parte dell'utente
