### PR TITLE
empty di sesso non lasciava passare le donne #558 #770

### DIFF
--- a/inc/nuovaAnagrafica.ok.php
+++ b/inc/nuovaAnagrafica.ok.php
@@ -8,7 +8,7 @@
  * Normalizzazione dei dati
  */
 
-$parametri = array('id', 'inputNome', 'inputCognome', 'inputSesso', 'inputDataNascita', 
+$parametri = array('id', 'inputNome', 'inputCognome', 'inputDataNascita', 
 	'inputProvinciaNascita', 'inputComuneNascita', 'inputComuneResidenza', 'inputCAPResidenza',
 	'inputProvinciaResidenza', 'inputIndirizzo', 'inputCivico');
 controllaParametri($parametri, 'nuovaAnagrafica&err');

--- a/inc/us.utente.nuovo.ok.php
+++ b/inc/us.utente.nuovo.ok.php
@@ -7,7 +7,7 @@
 paginaApp([APP_SOCI , APP_PRESIDENTE]);
 
 $parametri = array('inputComitato', 'inputCodiceFiscale', 'inputNome',
-	'inputCognome', 'inputSesso', 'inputDataNascita', 'inputDataIngresso');
+	'inputCognome', 'inputDataNascita', 'inputDataIngresso');
 controllaParametri($parametri, 'us.dash&err');
 
 $comitato = $_POST['inputComitato'];


### PR DESCRIPTION
Il check parametri non lasciava passare le donne, ora è risolto. fix #770 

Possiamo anche dire che la verifica parametri in registrazione è a posto fix #558 
