### PR TITLE
Niente email doppione da admin

### DIFF
--- a/inc/presidente.utente.modifica.ok.php
+++ b/inc/presidente.utente.modifica.ok.php
@@ -24,17 +24,9 @@ $caresidenza= normalizzaNome($_POST['inputCAPResidenza']);
 $prresidenza= maiuscolo($_POST['inputProvinciaResidenza']);
 $indirizzo  = normalizzaNome($_POST['inputIndirizzo']);
 $civico     = maiuscolo($_POST['inputCivico']);
-
 $cell       = normalizzaNome($_POST['inputCellulare']);
 $cells      = normalizzaNome(@$_POST['inputCellulareServizio']);
 
-if ($me->admin()) {
-	$nome       = normalizzaNome($_POST['inputNome']);
-	$cognome    = normalizzaNome($_POST['inputCognome']);
-	$sesso 		= $_POST['inputSesso'];
-	$codiceFiscale = maiuscolo($_POST['inputCodiceFiscale']);
-	$email      = minuscolo($_POST['inputEmail']);
-}
 /*
  * Controlla esistenza varia e ti porta dove dovrebbe 
  */
@@ -58,10 +50,23 @@ $p->timestamp           = time();
 $p->stato               = VOLONTARIO;
 
 if ($me->admin()) {
+	$nome       = normalizzaNome($_POST['inputNome']);
+	$cognome    = normalizzaNome($_POST['inputCognome']);
+	$sesso 		= $_POST['inputSesso'];
+	$codiceFiscale = maiuscolo($_POST['inputCodiceFiscale']);
+	$email      = minuscolo($_POST['inputEmail']);
+	/*
+ 	 * Controlla se sto scrivendo una email in possesso ad altro utente
+ 	 */
+	$e = Utente::by('email', $email);
+	if($e!=$id){
+		redirect('presidente.utente.visualizza&email&id='.$_GET['t']);
+	}
 	$p->nome                = $nome;
 	$p->cognome             = $cognome;
 	$p->sesso 				= ($sesso) ? UOMO : DONNA;
 	$p->codiceFiscale = $codiceFiscale;
+
 	$p->email               = $email;
 }
 

--- a/inc/presidente.utente.visualizza.php
+++ b/inc/presidente.utente.visualizza.php
@@ -20,15 +20,20 @@ proteggiDatiSensibili($u, [APP_SOCI, APP_PRESIDENTE]);
 <div class="row-fluid">
   <div class="span6">
     <?php if ( isset($_GET['ok']) ) { ?>
-    <div class="alert alert-success">
-      <i class="icon-save"></i> <strong>Salvato</strong>.
-      Le modifiche richieste sono state memorizzate con successo.
-    </div>
+      <div class="alert alert-success">
+        <i class="icon-save"></i> <strong>Salvato</strong>.
+        Le modifiche richieste sono state memorizzate con successo.
+      </div>
     <?php } elseif(isset($_GET['att'])) {?>
-    <div class="alert alert-success">
-      <i class="icon-user"></i> <strong>Account attivato</strong>.
-      L'account dell'utente è stato attivato con successo.
-    </div>
+      <div class="alert alert-success">
+        <i class="icon-user"></i> <strong>Account attivato</strong>.
+        L'account dell'utente è stato attivato con successo.
+      </div>
+    <?php } elseif(isset($_GET['email'])) {?>
+      <div class="alert alert-danger">
+        <i class="icon-warning-sign"></i> <strong>Email già presente</strong>.
+        L'email che si sta tentando di sostituire appartiene già ad un altro utente.
+      </div>
     <?php } ?>
 
     <!-- Attivazione account -->


### PR DESCRIPTION
Impedisce durante la modifica di una anagrafica di inserire una email già assegnata ad un altro utente fix #810 
