### PR TITLE
nuova funzione Appartenenza::validaPerAnzianita() #848

### DIFF
--- a/core/class/Appartenenza.class.php
+++ b/core/class/Appartenenza.class.php
@@ -75,4 +75,16 @@ class Appartenenza extends Entita {
             return;
         }
 
+        /**
+         * Le appartenenze valide per anzianità sono quelle dei 
+         * membri trasferiti o quelle dei membri volontari
+         * @return bool True se valida, False altrimenti
+         */
+        public function validaPerAnzianita() {
+            if($this->stato == MEMBRO_VOLONTARIO || $this->statp == MEMBRO_TRASFERITO) {
+                return true;
+            }
+            return false;
+        }
+
 }

--- a/core/class/Utente.class.php
+++ b/core/class/Utente.class.php
@@ -286,9 +286,15 @@ class Utente extends Persona {
     public function primaAppartenenza() {
         $p = Appartenenza::filtra([
             ['volontario',  $this->id]
-        ], 'inizio ASC LIMIT 0, 1');
+        ], 'inizio ASC');
         if ( !$p ) { return false; }
-        return $p[0];
+        $r = [];
+        foreach ($p as $_p){
+            if($_p->validaPerAnzianita()) {
+                $r[] = $_p;
+            }
+        }
+        return $r[0];
     }
 
     public function ultimaAppartenenza($stato = MEMBRO_VOLONTARIO) {


### PR DESCRIPTION
La funzione provaAppartenenza() prendeva per buono tutto, comprese estensioni & co e l'ASC non funzionava granchè, vediamo se così è meglio.

fix #848 
