### PR TITLE
migliorati i colori delle attività nel caneldario #837

### DIFF
--- a/core/class/APIServer.class.php
+++ b/core/class/APIServer.class.php
@@ -166,14 +166,14 @@ class APIServer {
                 $geoAttivita = GeoPolitica::daOid($attivita->comitato);
                 if ( $geoAttivita->contiene($mioGeoComitato) ) {
                     $colore = $conf['attivita']['colore_mie'];
+                    if ( $turno->scoperto() ) {
+                        $colore = $conf['attivita']['colore_scoperto'];
+                    }
                 } else {
                     $colore = $conf['attivita']['colore_pubbliche'];
                 }
-                if ( $turno->scoperto() ) {
-                    $colore = $conf['attivita']['colore_scoperto'];
-                }
             } else {
-                $colore = $conf['attivita']['colore_pubbliche'];
+                $colore = $conf['attivita']['colore_anonimi'];
             }
             $r[] = [
                 'turno'         =>  [

--- a/core/conf/generale.conf.php
+++ b/core/conf/generale.conf.php
@@ -29,6 +29,7 @@ $conf['slide'] = ['home'];
 $conf['mesi'] = [null, 'Gennaio', 'Febbraio', 'Marzo', 'Aprile', 'Maggio', 'Giugno', 'Luglio', 'Agosto', 'Settembre', 'Ottobre', 'Novembre', 'Dicembre'];
 
 /* Attivita, colori */
-$conf['attivita']['colore_pubbliche'] 	= '3135B0';
+$conf['attivita']['colore_pubbliche'] 	= '7E7AED';
 $conf['attivita']['colore_mie']			= '14CC00';
 $conf['attivita']['colore_scoperto'] 	= 'B20000';
+$conf['attivita']['colore_anonimi'] 	= '3135B0';


### PR DESCRIPTION
Rosso e verde per i comitati di cui faccio parte, azzurrino per tutto il resto del mondo. Blu per gli anonimi.

fix #837 
