### PR TITLE
corretta la visualizzazione sul pagamento quote #1028

### DIFF
--- a/core/class/Quota.php
+++ b/core/class/Quota.php
@@ -61,6 +61,10 @@ class Quota extends Entita {
         return DT::daTimestamp($this->timestamp);
     }
 
+    public function dataPagamento() {
+        return DT::daTimestamp($this->tConferma);
+    }
+
     public function annullata() {
         if ($this->pAnnullata && $this->tAnnullata) {
             return true;

--- a/inc/us.quote.visualizza.php
+++ b/inc/us.quote.visualizza.php
@@ -72,7 +72,7 @@ $q = Quota::filtra([['appartenenza', $app]], 'timestamp DESC');
                     <td><?= $_q->volontario()->nome; ?></td>
                     <td><?= $_q->volontario()->cognome; ?></td>
                     <td><?= $_q->comitato()->nomeCompleto(); ?></td>
-                    <td><?= date('d/m/Y', $_q->timestamp); ?></td>
+                    <td><?= $_q->dataPagamento()->inTesto(false); ?></td>
                     <td>€ <?php echo soldi($_q->quota);  ?></td>
                     <td>
                         <?php if($ann = $_q->annullata()) { ?>

--- a/inc/us.quoteSi.ordinari.php
+++ b/inc/us.quoteSi.ordinari.php
@@ -193,7 +193,7 @@ paginaApp([APP_SOCI , APP_PRESIDENTE]);
                                 echo('€ ' . soldi($q->quota));
                              }?>
                     </td>
-                    <td><?php echo $q->data()->inTesto(false); ?></td>
+                    <td><?php echo $q->dataPagamento()->inTesto(false); ?></td>
 
                     <td>
                         <div class="btn-group">

--- a/inc/us.quoteSi.php
+++ b/inc/us.quoteSi.php
@@ -191,7 +191,7 @@ paginaApp([APP_SOCI , APP_PRESIDENTE]);
                                 echo('€ ' . soldi($q->quota));
                              }?>
                     </td>
-                    <td><?php echo $q->data()->inTesto(false); ?></td>
+                    <td><?php echo $q->dataPagamento()->inTesto(false); ?></td>
 
                     <td>
                         <div class="btn-group">

--- a/inc/utente.storico.php
+++ b/inc/utente.storico.php
@@ -121,7 +121,7 @@ paginaPrivata();
             <tr>
                 <td><?= $_q->progressivo(); ?></td>
                 <td><?= $_q->comitato()->locale()->nomeCompleto(); ?></td>
-                <td><?= date('d/m/Y', $_q->timestamp); ?></td>
+                <td><?= $_q->dataPagamento()->inTesto(false); ?></td>
                 <td>
                     <?php if ($_q->benemerita()) { 
                         echo('€ ' . soldi($_q->quota)); 


### PR DESCRIPTION
in alcuni punti veniva visualizzata la data di effettuazione dell'operazione e non quella di registrazione effettiva del pagamento. fix #1028
