### PR TITLE
email con singolo destinatario senza indirizzo #1108

### DIFF
--- a/core/class/Email.php
+++ b/core/class/Email.php
@@ -135,7 +135,11 @@ class Email {
      * @return bool Operazione riuscita?
      */
     public function invia() {
-        return $this->accoda()->invia();
+        $m = $this->accoda();
+        if($m) {
+            $m->invia();
+        }
+        return false;            
 
     }
 
@@ -144,6 +148,13 @@ class Email {
      * @return MEmail creata
      */
     public function accoda() {
+
+        if($this->a && !is_array($this->a) ) {
+            $u = Utente::id($this->a);
+            if ( !$u->email || !filter_var($u->email, FILTER_VALIDATE_EMAIL)) {
+                return null;
+            }
+        }
 
         $x = new MEmail;
         $x->timestamp   = (int) time();


### PR DESCRIPTION
Risolve il problema delle email con singolo destinatario senza indirizzo o con indirizzo non valido. Non costruisce la MEmail e non la invia. Funziona anche se viene chiamato direttamente `invia()`. fix #1108 
