### PR TITLE
mittente nelle richieste di partecipazione #1052

### DIFF
--- a/core/class/Partecipazione.php
+++ b/core/class/Partecipazione.php
@@ -92,7 +92,7 @@ class Partecipazione extends Entita {
             $a->richiedi();
             
             $m = new Email('richiestaAutorizzazione', 'Richiesta autorizzazione partecipazione attività');
-            $m->da = $me;
+            $m->da           = $this->volontario();
             $m->a            = $this->turno()->attivita()->referente();
             $m->_NOME        = $this->turno()->attivita()->referente()->nome;
             $m->_ATTIVITA    = $this->turno()->attivita()->nome;


### PR DESCRIPTION
Richieste di partecipazione mandate dal mittente effettivo. Prima c'era un `$me` dentro la classe che ovviamente non funzionava... fix #1052 
