### PR TITLE
api controllava usava male funzione contiene() #1115

### DIFF
--- a/core/class/APIServer.php
+++ b/core/class/APIServer.php
@@ -229,7 +229,7 @@ class APIServer {
                 continue;
             }
             $geoAttivita = GeoPolitica::daOid($attivita->comitato);
-            if ( $this->sessione->utente ) {
+            if ( $mioGeoComitato ) {
                 if ( $geoAttivita->contiene($mioGeoComitato) ) {
                     $colore = $conf['attivita']['colore_mie'];
                     if ( $turno->scoperto() ) {


### PR DESCRIPTION
C'era un uso malsano delle geopolitiche e delle loro funzioni associate probabilmente causato da me. fix #1115 
