### PR TITLE
Incarico post trasferimento fix #1037

### DIFF
--- a/core/class/Trasferimento.php
+++ b/core/class/Trasferimento.php
@@ -131,7 +131,7 @@ class Trasferimento extends Entita {
             ['comitato',    $c->id]
             ]);
         
-        $presidente = $c->unPresidente();
+        $presidente = $c->primoPresidente();
         foreach ($att as $_att) {
             $_att->referente = $presidente->id;
         }


### PR DESCRIPTION
- Inserisce in tutte le attività superiori al locale il corretto
  presidente rimuovendo l'incarico al trasferito
