### PR TITLE
Fix #1018, ridotta dimensione minima schermo per modali

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -389,3 +389,21 @@ body {
     line-height: 1em;
     text-shadow: 3px 3px 0px white;
 }
+
+/**
+* Issue #1018 (https://github.com/CroceRossaCatania/gaia/issues/1018)
+* Modali senza scroll in bassa risoluzione
+*
+* Adottata soluzione: http://stackoverflow.com/questions/9899676/twitter-bootstrap-scrollable-modal
+* ma, invece di modificare bootstrap.css, ripristinato default CSS overflow-y per .modal
+*/
+.modal {
+  overflow-y: visible;
+}
+.modal .modal-body {
+  max-height: 420px;
+  overflow-y: auto;
+}
+.modal.fade.in {
+  top: 5%;
+}


### PR DESCRIPTION
Ridotta di a circa 525px la risoluzione minima per il corretto utilizzo dei modali. I messaggi a video lunghi sono ora provvisti di barre di scorrimento verticali.
