### PR TITLE
Fix #1413, doppia autorizzazione attività esterne

### DIFF
--- a/core/class/Partecipazione.php
+++ b/core/class/Partecipazione.php
@@ -129,7 +129,6 @@ class Partecipazione extends Entita {
             
             // Al mio...
             
-            /* HOTFIX TEMPORANEO 
             $a = new Autorizzazione();
             $a->partecipazione = $this->id;
             $a->volontario     = $this->volontario()->appartenenzaAttuale()->comitato()->primoPresidente()->id;
@@ -145,7 +144,6 @@ class Partecipazione extends Entita {
             $m->_TURNO       = $this->turno()->nome;
             $m->_DATA        = $a->timestamp()->format('d-m-Y H:i');
             $m->invia();
-            */
              
         }
         


### PR DESCRIPTION
Riattiva il meccanismo per cui se attività esterna al mio comitato chiedo autorizzazione al mio presidente e al referente dell'attività
