### PR TITLE
Fix #1753, link ai criteri nella mail di negazione

### DIFF
--- a/core/conf/mail/modelli/fototesseraNo.html
+++ b/core/conf/mail/modelli/fototesseraNo.html
@@ -1,3 +1,4 @@
 <p class="grassetto">Ciao _NOME</p>
 <p>La tua fototessera <b>non è stata confermata</b>.</p>
+<p>Ti ricordiamo che la fototessera deve rispettare i criteri descritti al seguente link <a href="http://wiki.gaia.cri.it/index.php?title=Manuale_del_Volontario#Foto_Tesserino"> link criteri </a></p>
 <p>Se pensi che ci sia stato un errore, ti invitiamo a rispondere a questa email indicandoci cosa c'è da correggere.</p>


### PR DESCRIPTION
Quando negata fototessera, nella mail di negazione viene inserito il
link ai criteri