### PR TITLE
Fix data immatricolazione

### DIFF
--- a/inc/autoparco.veicolo.nuovo.ok.php
+++ b/inc/autoparco.veicolo.nuovo.ok.php
@@ -53,7 +53,7 @@ if (!$libretto){
     $t->marca                   = $_POST['inputMarca'];
     $t->tipo                    = $_POST['inputTipo'];
     $t->massa                   = $_POST['inputMaxMassa'];
-    $immatricolazione           = @DateTime::createFromFormat('d/m/Y', $_POST['inputPrimaImmatricolazione']);
+    $immatricolazione           = @DateTime::createFromFormat('d/m/Y', $_POST['inputImmatricolazione']);
 	$immatricolazione           = @$immatricolazione->getTimestamp();
     $t->immatricolazione        = $immatricolazione;
     $t->categoria               = $_POST['inputCategoria'];


### PR DESCRIPTION
Fixes #1767 
La data della prima immatricolazione era usata anche per l'immatricolazione attuale.