### PR TITLE
Fix #1860, se attività chiusa non chiedo dettagli

### DIFF
--- a/core/class/Utente.php
+++ b/core/class/Utente.php
@@ -1046,7 +1046,8 @@ class Utente extends Persona {
     public function attivitaReferenziateDaCompletare() {
         return Attivita::filtra([
             ['referente',   $this->id],
-            ['stato',       ATT_STATO_BOZZA]
+            ['stato',       ATT_STATO_BOZZA],
+            ['apertura', ATT_APERTA]
         ]);
     }
 


### PR DESCRIPTION
Da testare:
- Se attività incompleta ma chiusa, non deve comparire reminder di completamento.