### PR TITLE
Fix vari alle quote

### DIFF
--- a/core/class/Utente.php
+++ b/core/class/Utente.php
@@ -2333,6 +2333,10 @@ class Utente extends Persona {
             if (in_array($appartenenza->stato, $conf['membro_invalido']))
                 continue;
 
+            // Se non appartenenza valida scopo quota, ignora
+            if (in_array($appartenenza->stato, $conf['membro_nonquota']))
+                continue;
+
             // Se appartenenza terminata con dimissione, termina esecuzione
             if (in_array($appartenenza->stato, $conf['membro_dimesso']))
                 continue;

--- a/core/class/Utente.php
+++ b/core/class/Utente.php
@@ -2344,6 +2344,16 @@ class Utente extends Persona {
             // In tutti gli altri casi, appartenenza legittima, passibile a pagamento quota per l'A.A.
             $r[] = $appartenenza;
 
+            // Se ho registrato una quota per questa appartenenza, le appartenenze
+            // precedenti non sono passibili di quota.
+            if ( Quota::conta([
+                ['appartenenza',    $appartenenza->id],
+                ['anno',            $anno],
+                ['pAnnullata',      false, OP_NULL]
+            ]) ) {
+                break;
+            }
+
         }
 
         return $r;

--- a/core/libs/costanti.php
+++ b/core/libs/costanti.php
@@ -135,7 +135,15 @@ $conf['membro_invalido'] = [
     MEMBRO_TRASF_IN_CORSO,
     MEMBRO_PENDENTE,
     MEMBRO_EST_PENDENTE,
-    MEMBRO_APP_NEGATA
+    MEMBRO_APP_NEGATA,
+    MEMBRO_EST_ANN
+
+];
+
+/* Appartenenze, oltre a membro_invalido, non valide ai fini della quota associativa */
+$conf['membro_nonquota'] = [
+    MEMBRO_ESTESO,
+    MEMBRO_EST_TERMINATA,
 ];
 
 /* Le tipologie di appartenenza che rappresentano dimissione da CRI */

--- a/inc/presidente.appartenenze.storico.php
+++ b/inc/presidente.appartenenze.storico.php
@@ -11,7 +11,18 @@ controllaParametri(array('id'));
 $v = $_GET['id'];
 $v = Volontario::id($v);
 proteggiDatiSensibili($v, [APP_SOCI, APP_PRESIDENTE]);
+
 ?>
+
+<pre>
+<?php 
+    foreach($v->appartenenzePassibiliQuota() as $k) {
+        var_dump($k);
+        var_dump($conf['membro'][$k->stato]);
+    } 
+?>
+</pre>
+
 <div class="row-fluid">
     <div class="span12">
         <div class="row-fluid">


### PR DESCRIPTION
Da testare:
- [x] I comitato presso cui sono esteso non sono considerati a scopo quote (non sono nei loro elenchi quote pagate o non)
- [ ] Risoluzione `IGM-340-97207` e similari (il volontario aveva terminato estensione presso quel comitato e risultava ancora li)
- [x] Se mi trasferisco e pago la quota, non compaio nei comitati dove ho avuto un'altra appartenenza precedente nello stesso anno
- [x] Risoluzione casi come `EEQ-578-85665`
- [ ] Risoluzione casi come `QDG-281-98519` parti 1 e 2

Per favore, @biagiosaitta, considera che molti di questi casi sono recenti e non presenti nel DB di test quindi bisogna ricreare situazioni simili. E' molto importante questa cosa funzioni bene per Roma.