### PR TITLE
permette di iscrivere finche corso aperto

### DIFF
--- a/core/class/GeoPolitica.php
+++ b/core/class/GeoPolitica.php
@@ -61,7 +61,7 @@ abstract class GeoPolitica extends GeoEntita {
 
         $r = [];
         foreach ($c as $_c) {
-            if ( !$_c->finito() )
+            if ( !$_c->concluso() )
                 $r[] = $_c; 
         }
         if ( $inCorso ) 


### PR DESCRIPTION
Su Gaia, a livello di codice, è possibile iscrivere un socio ordinario ad un corso base fino a che non è stato chiuso il corso (il direttore clicca il pulsantone per chiuderlo e generare il verbale). La pagina che permette le iscrizioni però mostra solamente i corsi che non hanno ancora superato la data di chiusura. Questo fix risolve il problema mostrando tutti i corsi non conclusi.

Non ho un db di test e non posso effettuare il test ma vi lascio le istruzioni per farlo:
1. Loggatevi col mio utente e selezionate la delega responsabile formazione
2. Andate nell'elenco soci ordinari e provate ad aggiungerne uno ad un corso
3. Nel menù a tendina dovrebbero comparirvi 2 corsi (BASE-2015/131 e BASE-2015/132)
4. Se succede ciò il fix ha funzionato correttamente

Non ci sono altri punti del codice che vengono intaccati in quanto la funzione viene chiamato solamente in quella pagina.

Grazie
CiaoCiao