### PR TITLE
Problema registrazione data quota nuovi soci ordinari

### DIFF
--- a/inc/us.ordinario.nuovo.ok.php
+++ b/inc/us.ordinario.nuovo.ok.php
@@ -112,9 +112,7 @@ if(!$gia){
 	$a = new Appartenenza();
 	$a->volontario  = $p->id;
 	$a->comitato    = $comitato;
-	$inizio 		= DT::createFromFormat('d/m/Y', $_POST['inputDataQuota']);
-	$inizio 		= $inizio->getTimestamp();
-	$a->inizio      = $inizio;
+	$a->inizio      = $dataQuota->getTimestamp();
 	$a->fine        = PROSSIMA_SCADENZA;
 	$a->timestamp 	= time();
 	$a->stato     	= MEMBRO_ORDINARIO;
@@ -127,7 +125,7 @@ $quotaMin = $t->ordinario;
 
 $q = new Quota();
 $q->appartenenza 	= $a;
-$q->timestamp 		= time();
+$q->timestamp 		= $dataQuota->getTimestamp();
 $q->tConferma 		= time();
 $q->pConferma 		= $me;
 $q->anno 			= $anno;


### PR DESCRIPTION
Ciao,
quando si iscrive un nuovo socio ordinario viene memorizzata in maniera errata la data di versamento della quota che non coincide con quella che viene inserita nel campo data pagamento ma viene generata con un `time()` a differenza di quello che succede per tutti gli altri tipi di quote che vengono registrate.

Questo problema sembra affliggere solo la registrazione delle quote dei nuovi soci ordinari.

Per testare il fix basta iscrivere un nuovo socio ordinare, datare il suo accesso a una data passata e verificare che sulla quota la data di patamento riportata stia effettivametne nel passato e non sia quella attuale.

CiaoCiao
luca