### PR TITLE
Fix #2002, Disattivazione dei Comitati in Gaia

### DIFF
--- a/core/class/GeoPolitica.php
+++ b/core/class/GeoPolitica.php
@@ -116,11 +116,13 @@ abstract class GeoPolitica extends GeoEntita {
      * Ritorna l'espansione della ricerca in basso nell'albero partendo da questo nodo
      * @param int $estensione   Opzionale. Estensione da raggiungere nell'albero. Uno di EST_*
      * @param int $ricerca      Opzionale. ESPLORA_RAMI | ESPLORA_SOLO_FOGLIE. Default ESPLORA_RAMI.
+     * @param bool $disattivi   Opzionale. Se vero E esplorazione NON solo foglie, include anche disattivi. Default False.
      * @return array(GeoPolitica)
      */
     public function esplora(
         $estensione = EST_UNITA,
-        $ricerca    = ESPLORA_RAMI
+        $ricerca    = ESPLORA_RAMI,
+        $disattivi  = false
     ) {
         if ( $ricerca == ESPLORA_SOLO_FOGLIE )
             return $this->estensione();
@@ -129,8 +131,8 @@ abstract class GeoPolitica extends GeoEntita {
             return [$this];
         } else {
             $r = [$this];
-            foreach ( $this->figli() as $f ) {
-                $r = array_merge($r, $f->esplora($estensione, ESPLORA_RAMI));
+            foreach ( $this->figli($disattivi) as $f ) {
+                $r = array_merge($r, $f->esplora($estensione, ESPLORA_RAMI, $disattivi));
             }
             return $r;
         }

--- a/core/class/GeoPolitica.php
+++ b/core/class/GeoPolitica.php
@@ -417,5 +417,18 @@ abstract class GeoPolitica extends GeoEntita {
 
         parent::cancella();
     }
+
+    /**
+     * Sovrascrive Entita::elenco filtrando in automatico per comitati Attivi.
+     * @param mostraDisattivi Opzionale. Se true, mostra anche Comitati disattivi.
+     * @return array(GeoPolitica)
+     */
+    public static function elenco($mostraDisattivi = false) {
+        if ( $mostraDisattivi ) { 
+            return parent::elenco();
+        } else {
+            return static::filtra([['attivo', 1]], 'nome ASC');
+        }
+    }
     
 }

--- a/core/class/Locale.php
+++ b/core/class/Locale.php
@@ -28,18 +28,25 @@ class Locale extends GeoPolitica {
         return array_merge($r, $this->comitati());
     }
 
-    public function figli() {
-        return $this->comitati();
+    public function figli($mostraDisattivi = false) {
+        return $this->comitati($mostraDisattivi);
     }
 
     public function superiore() {
         return $this->provinciale();
     }
 
-    public function comitati() {
-        return Comitato::filtra([
-            ['locale',  $this->id]
-        ], 'nome ASC');
+    public function comitati($mostraDisattivi = false) {
+        if ( $mostraDisattivi ) {
+            return Comitato::filtra([
+                ['locale',  $this->id]
+            ], 'nome ASC');
+        } else {
+            return Comitato::filtra([
+                ['locale',  $this->id],
+                ['attivo',  1]
+            ], 'nome ASC');
+        }
     }    
 
     public function aree($obiettivo = null, $espandiLocali = false ) {

--- a/core/class/Nazionale.php
+++ b/core/class/Nazionale.php
@@ -30,18 +30,25 @@ class Nazionale extends GeoPolitica {
         return array_unique($r);
     }
 
-    public function figli() {
-        return $this->regionali();
+    public function figli($mostraDisattivi = false) {
+        return $this->regionali($mostraDisattivi);
     }
 
     public function superiore() {
         return false;
     }
     
-    public function regionali() {
-        return Regionale::filtra([
-            ['nazionale',  $this->id]
-        ], 'nome ASC');
+    public function regionali($mostraDisattivi = false) {
+        if ( $mostraDisattivi ) {
+            return Regionale::filtra([
+                ['nazionale',  $this->id],
+            ], 'nome ASC');
+        } else {
+            return Regionale::filtra([
+                ['nazionale',  $this->id],
+                ['attivo',     1],
+            ], 'nome ASC');
+        }
     }
     
     public function toJSON() {

--- a/core/class/Provinciale.php
+++ b/core/class/Provinciale.php
@@ -30,18 +30,25 @@ class Provinciale extends GeoPolitica {
         return array_unique($r);
     }
 
-    public function figli() {
-        return $this->locali();
+    public function figli($mostraDisattivi = false) {
+        return $this->locali($mostraDisattivi);
     }
 
     public function superiore() {
         return $this->regionale();
     }
 
-    public function locali() {
-        return Locale::filtra([
-            ['provinciale',  $this->id]
-        ], 'nome ASC');
+    public function locali($mostraDisattivi = false) {
+        if ( $mostraDisattivi ) {
+            return Locale::filtra([
+                ['provinciale',  $this->id]
+            ], 'nome ASC');
+        } else {
+            return Locale::filtra([
+                ['provinciale',  $this->id],
+                ['attivo',       1]
+            ]);
+        }
     }
     
     public function regionale() {

--- a/core/class/Regionale.php
+++ b/core/class/Regionale.php
@@ -31,18 +31,25 @@ class Regionale extends GeoPolitica {
         return array_unique($r);
     }
 
-    public function figli() {
-        return $this->provinciali();
+    public function figli($mostraDisattivi = false) {
+        return $this->provinciali($mostraDisattivi);
     }
 
     public function superiore() {
         return $this->nazionale();
     }
     
-    public function provinciali() {
-        return Provinciale::filtra([
-            ['regionale',  $this->id]
-        ], 'nome ASC');
+    public function provinciali($mostraDisattivi = false) {
+        if ( $mostraDisattivi ) {
+            return Provinciale::filtra([
+                ['regionale',  $this->id]
+            ], 'nome ASC');
+        } else {
+            return Provinciale::filtra([
+                ['regionale',  $this->id],
+                ['attivo',     1],
+            ], 'nome ASC');
+        }
     }
     
     public function nazionale() {

--- a/inc/admin.comitati.attivazione.php
+++ b/inc/admin.comitati.attivazione.php
@@ -15,8 +15,8 @@ $n = (int) !((bool) $g->attivo);
 $g->attivo = $n;
 
 // Attiva/disattiva tutti i figli
-foreach ( $g->esplora() as $x ) {
+foreach ( $g->esplora(EST_UNITA, ESPLORA_RAMI, true) as $x ) {
 	$x->attivo = $n;
 }
 
-redirect('admin.comitati');
+redirect('admin.comitati&ad');

--- a/inc/admin.comitati.attivazione.php
+++ b/inc/admin.comitati.attivazione.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * (c)2015 Croce Rossa Italiana
+ */
+
+paginaAdmin();
+
+$g = $_GET['oid'];
+$g = GeoPolitica::daOid($g);
+
+$n = (int) !((bool) $g->attivo);
+
+// Attiva/disattiva
+$g->attivo = $n;
+
+// Attiva/disattiva tutti i figli
+foreach ( $g->esplora() as $x ) {
+	$x->attivo = $n;
+}
+
+redirect('admin.comitati');

--- a/inc/admin.comitati.php
+++ b/inc/admin.comitati.php
@@ -38,6 +38,11 @@ paginaAdmin();
         <i class="icon-warning-sign"></i> <strong>Quote correlate</strong>.
         Attenzione il Comitato che si vuole cancellare ha delle quote correlate, rimuoverle e riprovare.
     </div>
+<?php }elseif ( isset($_GET['ad']) ) { ?>
+    <div class="alert alert-warning">
+        <i class="icon-warning-sign"></i> <strong>Ricorda di rigenerare l'albero</strong>.
+        Per applicare le modifica di attivazione e disattivazione, <a href="?p=admin.reset.comitati">rigenera l'albero</a>.
+    </div>
 <?php } elseif ( isset($_GET['spostato']) ) { ?>
         <div class="alert alert-success">
             <i class="icon-save"></i> <strong>Comitato spostato con successo</strong>.
@@ -54,6 +59,8 @@ paginaAdmin();
 <br/>
 
 <?php
+
+$mostraDisattivi = true;
 
 function pulsanteAttivo($geopolitica) { 
     if ( $geopolitica->attivo ) {
@@ -98,7 +105,7 @@ function pulsanteAttivo($geopolitica) {
             <th>Attivo?</th>
         </thead>
         <?php
-        foreach ( Nazionale::elenco() as $nazionale ){
+        foreach ( Nazionale::elenco($mostraDisattivi) as $nazionale ){
             ?>
             <tr>
                 <td colspan="5"><strong><?php echo $nazionale->nome; ?></strong></td>
@@ -114,7 +121,7 @@ function pulsanteAttivo($geopolitica) {
                 </td>
                 <td><?php pulsanteAttivo($nazionale); ?></td>
             </tr>
-            <?php foreach ( $nazionale->regionali() as $regionale ) { ?>
+            <?php foreach ( $nazionale->regionali($mostraDisattivi) as $regionale ) { ?>
             <tr class="success">
                 <td></td>
                 <td colspan="4" border-left="none"><?php echo $regionale->nome; ?></td>
@@ -136,7 +143,7 @@ function pulsanteAttivo($geopolitica) {
                 </td>
                 <td><?php pulsanteAttivo($regionale); ?></td>
             </tr>
-            <?php foreach ( $regionale->provinciali() as $provinciale ) { ?>
+            <?php foreach ( $regionale->provinciali($mostraDisattivi) as $provinciale ) { ?>
             <tr class="error">
                 <td></td><td></td>
                 <td colspan="3"><?php echo $provinciale->nome; ?></td>
@@ -161,7 +168,7 @@ function pulsanteAttivo($geopolitica) {
                 </td>
                 <td><?php pulsanteAttivo($provinciale); ?></td>
             </tr>
-            <?php foreach ( $provinciale->locali() as $locale ) { ?>
+            <?php foreach ( $provinciale->locali($mostraDisattivi) as $locale ) { ?>
             <tr class="alert">
                 <td></td><td></td><td></td>
                 <td colspan="2">
@@ -196,7 +203,7 @@ function pulsanteAttivo($geopolitica) {
             </td>
             <td><?php pulsanteAttivo($locale); ?></td>
         </tr>
-        <?php foreach ( $locale->comitati() as $comitato ) { ?>
+        <?php foreach ( $locale->comitati($mostraDisattivi) as $comitato ) { ?>
         <tr class="info">
             <td></td><td></td><td></td><td></td>
             <td colspan="1">

--- a/inc/admin.comitati.php
+++ b/inc/admin.comitati.php
@@ -53,6 +53,26 @@ paginaAdmin();
 <script type="text/javascript"><?php require './assets/js/presidente.utenti.js'; ?></script>
 <br/>
 
+<?php
+
+function pulsanteAttivo($geopolitica) { 
+    if ( $geopolitica->attivo ) {
+        ?>
+        <i class="icon-check text-success"></i> Attivo 
+        (<a href="?p=admin.comitati.attivazione&oid=<?= $geopolitica->oid(); ?>" data-conferma="DISATTIVAZIONE: Questa operazione verr&agrave; effettuata sul comitato e tutti i figli.">Disattiva</a>)
+        <?php 
+    } else {
+        ?>
+        <i class="icon-check-empty text-warning"></i> Disattivo
+        (<a href="?p=admin.comitati.attivazione&oid=<?= $geopolitica->oid(); ?>" data-conferma="ATTIVAZIONE: Questa operazione verr&agrave; effettuata sul comitato e tutti i figli.">Disattiva</a>)
+        <?php
+    }
+
+
+} 
+
+?>
+
 <div class="row-fluid">
     <div class="span8">
         <h2>
@@ -75,6 +95,7 @@ paginaAdmin();
         <thead>
             <th>Nome</th>
             <th>Azioni</th>
+            <th>Attivo?</th>
         </thead>
         <?php
         foreach ( Nazionale::elenco() as $nazionale ){
@@ -82,60 +103,63 @@ paginaAdmin();
             <tr>
                 <td colspan="5"><strong><?php echo $nazionale->nome; ?></strong></td>
                 <td>
-                    <div class="btn-group">
-                        <a class="btn btn-small" href="?p=presidente.comitato&oid=<?php echo $nazionale->oid(); ?>" title="Dettagli">
+                    <div class="ex-btngroup">
+                        <a class="ex-btnmini" href="?p=presidente.comitato&oid=<?php echo $nazionale->oid(); ?>" title="Dettagli">
                             <i class="icon-eye-open"></i> Dettagli
                         </a>
-                        <a class="btn btn-small btn-success" href="?p=admin.comitato.nuovo&id=<?php echo $nazionale->id; ?>&t=regi" title="Nuovo">
+                        <a class="ex-btnmini btn-success" href="?p=admin.comitato.nuovo&id=<?php echo $nazionale->id; ?>&t=regi" title="Nuovo">
                             <i class="icon-plus"></i> Nuovo
                         </a>
                     </div>
                 </td>
+                <td><?php pulsanteAttivo($nazionale); ?></td>
             </tr>
             <?php foreach ( $nazionale->regionali() as $regionale ) { ?>
             <tr class="success">
                 <td></td>
                 <td colspan="4" border-left="none"><?php echo $regionale->nome; ?></td>
                 <td>
-                    <div class="btn-group">
-                        <a class="btn btn-small" href="?p=presidente.comitato&oid=<?php echo $regionale->oid(); ?>" title="Dettagli">
+                    <div class="ex-btngroup">
+                        <a class="ex-btnmini" href="?p=presidente.comitato&oid=<?php echo $regionale->oid(); ?>" title="Dettagli">
                             <i class="icon-eye-open"></i> Dettagli
                         </a>    
-                        <a class="btn btn-small btn-info" href="?p=admin.comitato.modifica&oid=<?php echo $regionale->oid(); ?>" title="Modifica">
+                        <a class="ex-btnmini btn-info" href="?p=admin.comitato.modifica&oid=<?php echo $regionale->oid(); ?>" title="Modifica">
                             <i class="icon-edit"></i> Modifica
                         </a>
-                        <a class="btn btn-small btn-success" href="?p=admin.comitato.nuovo&id=<?php echo $regionale->id; ?>&t=pro" title="Nuovo">
+                        <a class="ex-btnmini btn-success" href="?p=admin.comitato.nuovo&id=<?php echo $regionale->id; ?>&t=pro" title="Nuovo">
                             <i class="icon-plus"></i> Nuovo
                         </a>
-                        <a  onClick="return confirm('Vuoi veramente cancellare questo comitato ? Assicurati che non vi siano comitati o volontari correlati a questo!!!');" href="?p=admin.comitato.cancella&oid=<?php echo $regionale->oid(); ?>" title="Cancella Regionale" class="btn btn-small btn-danger">
+                        <a  onClick="return confirm('Vuoi veramente cancellare questo comitato ? Assicurati che non vi siano comitati o volontari correlati a questo!!!');" href="?p=admin.comitato.cancella&oid=<?php echo $regionale->oid(); ?>" title="Cancella Regionale" class="ex-btnmini btn-danger">
                             <i class="icon-trash"></i> Cancella
                         </a>
                     </div>
                 </td>
+                <td><?php pulsanteAttivo($regionale); ?></td>
             </tr>
             <?php foreach ( $regionale->provinciali() as $provinciale ) { ?>
             <tr class="error">
                 <td></td><td></td>
                 <td colspan="3"><?php echo $provinciale->nome; ?></td>
                 <td>
-                    <div class="btn-group">
-                        <a class="btn btn-small" href="?p=presidente.comitato&oid=<?php echo $provinciale->oid(); ?>" title="Dettagli">
+                    <div class="ex-btngroup">
+                        <a class="ex-btnmini" href="?p=presidente.comitato&oid=<?php echo $provinciale->oid(); ?>" title="Dettagli">
                             <i class="icon-eye-open"></i> Dettagli
                         </a>  
-                        <a class="btn btn-small btn-info" href="?p=admin.comitato.modifica&oid=<?php echo $provinciale->oid(); ?>" title="Modifica">
+                        <a class="ex-btnmini btn-info" href="?p=admin.comitato.modifica&oid=<?php echo $provinciale->oid(); ?>" title="Modifica">
                             <i class="icon-edit"></i> Modifica
                         </a>
-						<a class="btn btn-small btn-warning" href="?p=admin.comitato.sposta&oid=<?php echo $provinciale->oid(); ?>" title="Sposta">
+						<a class="ex-btnmini btn-warning" href="?p=admin.comitato.sposta&oid=<?php echo $provinciale->oid(); ?>" title="Sposta">
                             <i class="icon-arrow-right"></i> Sposta
                         </a>
-                        <a class="btn btn-small btn-success" href="?p=admin.comitato.nuovo&id=<?php echo $provinciale->id; ?>&t=loc" title="Nuovo">
+                        <a class="ex-btnmini btn-success" href="?p=admin.comitato.nuovo&id=<?php echo $provinciale->id; ?>&t=loc" title="Nuovo">
                             <i class="icon-plus"></i> Nuovo
                         </a> 
-                        <a  onClick="return confirm('Vuoi veramente cancellare questo comitato ? Assicurati che non vi siano comitati o volontari correlati a questo!!!');" href="?p=admin.comitato.cancella&oid=<?php echo $provinciale->oid(); ?>" title="Cancella Provinciale" class="btn btn-small btn-danger">
+                        <a  onClick="return confirm('Vuoi veramente cancellare questo comitato ? Assicurati che non vi siano comitati o volontari correlati a questo!!!');" href="?p=admin.comitato.cancella&oid=<?php echo $provinciale->oid(); ?>" title="Cancella Provinciale" class="ex-btnmini btn-danger">
                             <i class="icon-trash"></i> Cancella
                         </a>
                     </div>
                 </td>
+                <td><?php pulsanteAttivo($provinciale); ?></td>
             </tr>
             <?php foreach ( $provinciale->locali() as $locale ) { ?>
             <tr class="alert">
@@ -152,24 +176,25 @@ paginaAdmin();
 
             </td>
             <td>
-                <div class="btn-group">
-                    <a class="btn btn-small" href="?p=presidente.comitato&oid=<?php echo $locale->oid(); ?>" title="Dettagli">
+                <div class="ex-btngroup">
+                    <a class="ex-btnmini" href="?p=presidente.comitato&oid=<?php echo $locale->oid(); ?>" title="Dettagli">
                         <i class="icon-eye-open"></i> Dettagli
                     </a>     
-                    <a class="btn btn-small btn-info" href="?p=admin.comitato.modifica&oid=<?php echo $locale->oid(); ?>" title="Modifica">
+                    <a class="ex-btnmini btn-info" href="?p=admin.comitato.modifica&oid=<?php echo $locale->oid(); ?>" title="Modifica">
                         <i class="icon-edit"></i> Modifica
                     </a>
-					<a class="btn btn-small btn-warning" href="?p=admin.comitato.sposta&oid=<?php echo $locale->oid(); ?>" title="Sposta">
+					<a class="ex-btnmini btn-warning" href="?p=admin.comitato.sposta&oid=<?php echo $locale->oid(); ?>" title="Sposta">
                         <i class="icon-arrow-right"></i> Sposta
                     </a>
-                    <a class="btn btn-small btn-success" href="?p=admin.comitato.nuovo&id=<?php echo $locale->id; ?>&t=com" title="Nuovo">
+                    <a class="ex-btnmini btn-success" href="?p=admin.comitato.nuovo&id=<?php echo $locale->id; ?>&t=com" title="Nuovo">
                         <i class="icon-plus"></i> Nuovo
                     </a> 
-                    <a  onClick="return confirm('Vuoi veramente cancellare questo comitato ? Assicurati che non vi siano comitati o volontari correlati a questo!!!');" href="?p=admin.comitato.cancella&oid=<?php echo $locale->oid(); ?>" title="Cancella Locale" class="btn btn-small btn-danger">
+                    <a  onClick="return confirm('Vuoi veramente cancellare questo comitato ? Assicurati che non vi siano comitati o volontari correlati a questo!!!');" href="?p=admin.comitato.cancella&oid=<?php echo $locale->oid(); ?>" title="Cancella Locale" class="ex-btnmini btn-danger">
                         <i class="icon-trash"></i> Cancella
                     </a>
                 </div>
             </td>
+            <td><?php pulsanteAttivo($locale); ?></td>
         </tr>
         <?php foreach ( $locale->comitati() as $comitato ) { ?>
         <tr class="info">
@@ -188,21 +213,22 @@ paginaAdmin();
 
             </td>
             <td>
-                <div class="btn-group">
-                    <a class="btn btn-small" href="?p=presidente.comitato&oid=<?php echo $comitato->oid(); ?>" title="Dettagli">
+                <div class="ex-btngroup">
+                    <a class="ex-btnmini" href="?p=presidente.comitato&oid=<?php echo $comitato->oid(); ?>" title="Dettagli">
                         <i class="icon-eye-open"></i> Dettagli
                     </a>      
-                    <a class="btn btn-small btn-info" href="?p=admin.comitato.modifica&oid=<?php echo $comitato->oid(); ?>" title="Modifica">
+                    <a class="ex-btnmini btn-info" href="?p=admin.comitato.modifica&oid=<?php echo $comitato->oid(); ?>" title="Modifica">
                         <i class="icon-edit"></i> Modifica
                     </a>
- 					<a class="btn btn-small btn-warning" href="?p=admin.comitato.sposta&oid=<?php echo $comitato->oid(); ?>" title="Sposta">
+ 					<a class="ex-btnmini btn-warning" href="?p=admin.comitato.sposta&oid=<?php echo $comitato->oid(); ?>" title="Sposta">
                     	<i class="icon-arrow-right"></i> Sposta
                     </a>
-                    <a  onClick="return confirm('Vuoi veramente cancellare questo comitato ? Assicurati che non vi siano comitati o volontari correlati a questo!!!');" href="?p=admin.comitato.cancella&oid=<?php echo $comitato->oid(); ?>" title="Cancella Comitato" class="btn btn-small btn-danger">
+                    <a  onClick="return confirm('Vuoi veramente cancellare questo comitato ? Assicurati che non vi siano comitati o volontari correlati a questo!!!');" href="?p=admin.comitato.cancella&oid=<?php echo $comitato->oid(); ?>" title="Cancella Comitato" class="ex-btnmini btn-danger">
                         <i class="icon-trash"></i> Cancella
                     </a>
                 </div>
             </td>
+            <td><?php pulsanteAttivo($comitato); ?></td>
         </tr>
         <?php }}}}}
         

--- a/upload/setup/gaia.sql
+++ b/upload/setup/gaia.sql
@@ -164,6 +164,7 @@ CREATE TABLE IF NOT EXISTS `comitati` (
   `locale` int(11) DEFAULT NULL,
   `geo` point NOT NULL,
   `principale` tinyint(1) DEFAULT NULL,
+  `attivo` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `locale` (`locale`),
   SPATIAL KEY `geo` (`geo`)
@@ -501,6 +502,7 @@ CREATE TABLE IF NOT EXISTS `locali` (
   `nome` varchar(255) DEFAULT NULL,
   `geo` point NOT NULL,
   `provinciale` int(11) DEFAULT NULL,
+  `attivo` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `provinciale` (`provinciale`),
   SPATIAL KEY `geo` (`geo`)
@@ -539,6 +541,7 @@ CREATE TABLE IF NOT EXISTS `nazionali` (
   `id` int(11) NOT NULL,
   `nome` varchar(255) DEFAULT NULL,
   `geo` point NOT NULL,
+  `attivo` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   SPATIAL KEY `geo` (`geo`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
@@ -589,6 +592,7 @@ CREATE TABLE IF NOT EXISTS `provinciali` (
   `nome` varchar(255) DEFAULT NULL,
   `geo` point NOT NULL,
   `regionale` int(11) DEFAULT NULL,
+  `attivo` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `regionale` (`regionale`),
   SPATIAL KEY `geo` (`geo`)
@@ -633,6 +637,7 @@ CREATE TABLE IF NOT EXISTS `regionali` (
   `nome` varchar(255) DEFAULT NULL,
   `geo` point NOT NULL,
   `nazionale` int(11) DEFAULT NULL,
+  `attivo` tinyint(1) DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `nazionale` (`nazionale`),
   SPATIAL KEY `geo` (`geo`)


### PR DESCRIPTION
Questa PR:
* Introduce la possibilita' di attivare e disattivare i Comitati di ogni livello
* Nasconde i Comitati disattivi nell'Albero dei Comitati (usato dai selettori e tutte le funzioni in giro per Gaia, tranne nel pannello di amministrazione)
* Attivare e disattivare un comitato ha effetto sul comitato stesso e tutti i figli, ricorsivamente

Lo scopo e' quello di permettere la disattivazione dei Comitati evitando la necessita' di eliminarli, permettendo il formarsi dello storico.

## Prima del merge 

Eseguire il seguente SQL:
```sql
ALTER TABLE `comitati` ADD COLUMN (`attivo` TINYINT(1) DEFAULT 1);
ALTER TABLE `locali` ADD COLUMN (`attivo` TINYINT(1) DEFAULT 1);
ALTER TABLE `provinciali` ADD COLUMN (`attivo` TINYINT(1) DEFAULT 1);
ALTER TABLE `regionali` ADD COLUMN (`attivo` TINYINT(1) DEFAULT 1);
ALTER TABLE `nazionali` ADD COLUMN (`attivo` TINYINT(1) DEFAULT 1);
```

## Stato (spuntate)

- [x] Review @ico88 @AngeloLupo 
- [ ] Test @biagiosaitta 
- [x] Ack @matthewmazzoleni 
- [ ] Merge 
