### PR TITLE
Utenti supporto riepilogo

### DIFF
--- a/core/class/Utente.php
+++ b/core/class/Utente.php
@@ -45,6 +45,26 @@ class Utente extends Persona {
         }
         return $r;
     }
+    
+     public static function listaSupporto() {
+        global $db;
+        $q = $db->prepare("
+            SELECT
+                id
+            FROM
+                dettagliPersona
+            WHERE
+                nome > 0
+            ORDER BY
+                nome ASC, cognome ASC");
+        $q->execute();
+        $r = [];
+        while ( $k = $q->fetch(PDO::FETCH_NUM) ) {
+            $r[] = Utente::id($k[0]);
+        }
+        return $r;
+    }
+
 
     public static function senzaSesso() {
         global $db;

--- a/inc/admin.admin.php
+++ b/inc/admin.admin.php
@@ -25,14 +25,14 @@ paginaAdmin();
     <div class="span6 allinea-sinistra">
         <h2>
             <i class="icon-star muted"></i>
-            Elenco Admin
+            Elenco amministratori
         </h2>
     </div>
     
     <div class="span6 allinea-destra">
         <div class="input-prepend">
             <span class="add-on"><i class="icon-search"></i></span>
-            <input autofocus required id="cercaUtente" placeholder="Cerca Admin..." type="text">
+            <input autofocus required id="cercaUtente" placeholder="Cerca amministratore..." type="text">
         </div>
     </div>    
 </div>
@@ -55,7 +55,51 @@ paginaAdmin();
         <td><?php echo date('d-m-Y', $_v->dataNascita); ?></td> 
         <td><?php echo $_v->comuneNascita; ?></td>
         <td>
-            <a class="btn btn-danger btn-small" onClick="return confirm('Vuoi veramente revocare amministrazione a questo utente ?');" href="?p=admin.admin.dimetti&id=<?php echo $_v->id; ?>">
+            <a class="btn btn-danger btn-small" onClick="return confirm('Vuoi veramente revocare i privilegi a questo utente ?');" href="?p=admin.admin.dimetti&id=<?php echo $_v->id; ?>">
+                <i class="icon-ban-circle"></i>
+                Revoca
+            </a>
+        </td>
+    </tr>
+    <?php } ?>
+</table>
+
+
+<div class="row-fluid">
+    <div class="span6 allinea-sinistra">
+        <h2>
+            <i class="icon-star-empty muted"></i>
+            Elenco utenti con privilegi di supporto
+        </h2>
+    </div>
+    
+    <div class="span6 allinea-destra">
+        <div class="input-prepend">
+            <span class="add-on"><i class="icon-search"></i></span>
+            <input autofocus required id="cercaUtente" placeholder="Cerca utenti di supporto..." type="text">
+        </div>
+    </div>    
+</div>
+<hr />
+<table class="table table-striped table-bordered" id="tabellaUtenti">
+    <thead>
+        <th>Nome</th>
+        <th>Cognome</th>
+        <th>Codice Fiscale</th>
+        <th>Data di Nascita</th>
+        <th>Luogo di Nascita</th>
+        <th>Azione</th>
+    </thead>
+    <?php
+    foreach ( Utente::listaSupporto() as $_v ) {  ?>
+    <tr>
+        <td><?php echo $_v->nome; ?></td>
+        <td><?php echo $_v->cognome; ?></td>
+        <td><?php echo $_v->codiceFiscale; ?></td>
+        <td><?php echo date('d-m-Y', $_v->dataNascita); ?></td> 
+        <td><?php echo $_v->comuneNascita; ?></td>
+        <td>
+            <a class="btn btn-danger btn-small" onClick="return confirm('Vuoi veramente revocare i privilegi a questo utente ?');" href="?p=admin.nomina.supporto&id=<?php echo $_v->id; ?>">
                 <i class="icon-ban-circle"></i>
                 Revoca
             </a>

--- a/inc/presidente.utente.visualizza.php
+++ b/inc/presidente.utente.visualizza.php
@@ -422,17 +422,7 @@ $do = DonazionePersonale::filtra([['volontario', $u]]);
       <a class="btn btn-primary" href="?p=admin.beuser&id=<?= $id; ?>" title="Log in">
         <i class="icon-key"></i> Login
       </a>
-      <?php if($u->supporto == 0){ ?>
-        <a class="btn btn-success" href="?p=admin.nomina.supporto&id=<?= $id; ?>" title="Nomina supporto">
-          <i class="icon-plus-sign"></i> Nomina supporto
-        </a>
-
-      <?php }else{ ?>
-        <a class="btn btn-inverse" href="?p=admin.nomina.supporto&id=<?= $id; ?>" title="SNomina supporto">
-          <i class="icon-minus-sign"></i> Rimuovi nomina supporto
-        </a>
-      <?php } ?>
-      
+         
       <?php if(!Appartenenza::filtra([['volontario', $id]])) { ?>
       <a class="btn btn-info" href="?p=admin.limbo.comitato.nuovo&id=<?= $id; ?>" title="Assegna a Comitato" target="_new">
         <i class="icon-arrow-right"></i> Assegna a Comitato

--- a/inc/presidente.utenti.php
+++ b/inc/presidente.utenti.php
@@ -91,8 +91,11 @@ menuElenchiVolontari(
                 <a class="btn btn-small btn-primary" href="?p=admin.presidente.nuovo&id={id}" title="Nomina Presidente">
                     <i class="icon-star"></i>
                 </a> 
-                <a class="btn btn-small btn-danger" href="?p=admin.admin.nuovo&id={id}" title="Nomina Admin">
+                <a class="btn btn-small btn-danger" href="?p=admin.admin.nuovo&id={id}" title="Nomina amministratore">
                     <i class="icon-magic"></i>
+                </a>
+				<a class="btn btn-small btn-danger" href="?p=admin.nomina.supporto&id={id}" title="Nomina supporto">
+                    <i class="icon-heart"></i>
                 </a>
                 <?php } ?>
             </div>

--- a/index.php
+++ b/index.php
@@ -306,7 +306,7 @@ $_descrizione   = 'Crediamo in una Croce Rossa Italiana che sa muoversi veloceme
                                             <li><a href="?p=admin.ricerca.attivita"><i class="icon-calendar"></i> Cerca Attività</a></li> 
                                             <li><a href="?p=admin.presidenti"><i class="icon-list"></i> Presidenti</a></li>
                                             <li><a href="?p=admin.delegati"><i class="icon-list"></i> Delegati</a></li>
-                                            <li><a href="?p=admin.admin"><i class="icon-star"></i> Amministratori</a></li>
+                                            <li><a href="?p=admin.admin"><i class="icon-star"></i> Staff</a></li>
                                             <li><a href="?p=admin.comitati"><i class="icon-bookmark"></i> Comitati</a></li> 
                                             <li><a href="?p=admin.titoli"><i class="icon-certificate"></i> Titoli</a></li>
 											<li><a href="?p=admin.donazioni"><i class="icon-beaker"></i> Donazioni</a></li>


### PR DESCRIPTION
Permette la visualizzazione  / rimozione del personale nominato come "supporto" in un' unica pagina e la nomina direttamente dalla lista utenti.