### PR TITLE
Introduzione titoli certificati

### DIFF
--- a/inc/admin.titoli.php
+++ b/inc/admin.titoli.php
@@ -76,11 +76,14 @@ paginaAdmin();
                 <td><?php echo($conf['titoli'][$c->tipo][0]); ?></td>
                 <td>
                     <div class="btn-group">
-                        <a  onClick="return confirm('Vuoi veramente cancellare questo titolo ?');" href="?p=admin.titolo.cancella&id=<?php echo $c->id; ?>" title="Cancella Titolo" class="btn btn-small btn-warning">
+                        <a class="btn btn-small btn-danger" onClick="return confirm('Vuoi veramente cancellare questo titolo ?');" href="?p=admin.titolo.cancella&id=<?php echo $c->id; ?>" title="Cancella Titolo">
                             <i class="icon-trash"></i> Cancella
                         </a>
-                        <a  href="?p=admin.titolo.modifica&id=<?php echo $c->id; ?>" title="Modifica Titolo" class="btn btn-small btn-info">
+                        <a class="btn btn-small" href="?p=admin.titolo.modifica&id=<?php echo $c->id; ?>" title="Modifica Titolo">
                             <i class="icon-edit"></i> Modifica
+                        </a>
+                        <a class="btn btn-small btn-primary" href="?p=admin.titolo.volontari&id=<?= $c->id; ?>">
+                            <i class="icon-group"></i> Certificati
                         </a>
                     </div>
                 </td>

--- a/inc/admin.titolo.volontari.aggiungirimuovi.php
+++ b/inc/admin.titolo.volontari.aggiungirimuovi.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * (c)2015 Croce Rossa Italiana
+ */
+
+paginaAdmin();
+
+$t = Titolo::id($_POST['id']);
+
+$aggiungi = (bool) @$_POST['corso'];
+
+$cfs = $_POST['codicifiscali'];
+if (!$cfs) {
+	redirect("admin.titolo.volontari&id={$t->id}");
+}
+$cfs = explode("\n", $cfs);
+foreach ($cfs as &$cf) {
+	$cf = maiuscolo($cf);
+}
+
+$tot = 0;
+
+if ( $aggiungi ) {
+	// Aggiunta
+
+	foreach ($cfs as $cf) {
+
+		// 1. Controlla che esista la persona
+		$v = Utente::by('codiceFiscale', $cf);
+		if (!$v) { echo "No CF"; continue; }
+
+		// 2. Controlla che non abbia gia' il titolo
+		if ( TitoloPersonale::filtra([
+			['titolo', $t->id],
+			['volontario', $v->id]
+		]) ) {
+			continue;
+		}
+
+		// Ok, aggiungi.
+		
+		$a = new TitoloPersonale;
+		$a->volontario = $v->id;
+		$a->titolo = $t->id;
+		$a->inizio = strtotime($_POST['inizio']);
+		$a->fine = $_POST['fine'] ? strtotime($_POST['fine']) : null;
+		$a->pConferma = $_POST['pConferma'] ? $_POST['pConferma'] : $me->id;
+		$a->tConferma = time();
+		$a->luogo = $_POST['luogo'];
+		$a->corso = maiuscolo($_POST['corso']);
+
+		$tot++;
+
+	}
+
+
+} else {
+	// Rimozione
+
+	foreach ( $cfs as $cf ) {
+		// 1. Controlla che esista la persona
+		$v = Utente::by('codiceFiscale', $cf);
+		if (!$v) { continue; }
+
+		// 2. Controlla che non abbia gia' il titolo
+		if ( $a = TitoloPersonale::filtra([
+			['titolo', $t->id],
+			['volontario', $v->id]
+		]) ) {
+			$a = $a[0];
+			$a->cancella();
+			$tot++;
+		}
+
+	}
+
+}
+
+redirect("admin.titolo.volontari&id={$t->id}&tot={$tot}");

--- a/inc/admin.titolo.volontari.php
+++ b/inc/admin.titolo.volontari.php
@@ -1,0 +1,125 @@
+<?php
+
+/**
+ * (c)2015 Croce Rossa Italiana
+ */
+
+paginaAdmin();
+caricaSelettore();
+
+$t = Titolo::id($_GET['id']);
+
+$tp = TitoloPersonale::filtra([
+	['titolo', $t],
+	['corso', true, OP_NNULL]
+]);
+
+?>
+
+<script type="text/javascript">
+
+function _aggiungicf(codiceFiscale) {
+	$("#rimuovi").val($("#rimuovi").val() + "\n" + codiceFiscale);
+	$("#rimuovi").focus();
+}
+
+</script>
+
+<?php if ( isset($_GET['tot']) ) { ?>
+
+	<div class="alert alert-info">
+		<i class="icon-info-sign"></i> <strong>Sono stati aggiunti o rimossi n. <?= (int) $_GET['tot']; ?> elementi.</strong>
+	</div>
+
+<?php } ?>
+
+
+<div class="row-fluid">
+
+	<div class="span7">
+
+
+		<h3>
+			<i class="icon-asterisk text-muted"></i> 
+			Gestione volontari certificati 
+			(<strong><?= $t->nome; ?></strong>)
+		</h3>
+
+		<table class="table table-condensed table-bordered table-striped">
+		<thead>
+			<th>Volontario</th>
+			<th>Ottenimento, scadenza e luogo</th>
+			<th>Corso ed esaminatore</th>
+			<th><i class="icon-remove"></i></th>
+		</thead>
+		<tbody>
+			<?php foreach ($tp as $_tp) { 
+				$v = $_tp->volontario();
+				?>
+				<tr>
+					<td>
+						<span style="font-family: monospace;"><?= $v->codiceFiscale; ?></span><br />
+						<?= $v->nomeCompleto(); ?>
+					</td>
+					<td>
+						<?php echo date('d-m-Y', $_tp->inizio); ?>
+						&mdash;
+						<?php echo ($_tp->fine ? date('d-m-Y', $_tp->fine) : 'Attuale'); ?><br />
+						<?= $_tp->luogo; ?>
+					</td>
+					<td>
+						<span style="font-family: monospace;"><?= $_tp->corso; ?></span><br />
+						<?= $_tp->pConferma()->nomeCompleto(); ?>
+					</td>
+					<td>
+						<a href="javascript:_aggiungicf('<?= $v->codiceFiscale; ?>');">
+							<i class="icon-remove"></i>
+						</a>
+					</td>
+				</tr>
+			<?php } ?>
+
+		</tbody>
+		</table>
+	</div>
+
+
+	<div class="span3">
+		<h3><i class="icon-plus"></i> Aggiungi</h3>
+		<hr />
+
+		<form action="?p=admin.titolo.volontari.aggiungirimuovi" method="POST">
+			<input type="hidden" name="id" value="<?= $t->id; ?>" />
+
+			Codice corso: <input type="text" required name="corso" class="input-small" /><br />
+			Data esame: <input type="date" required name="inizio" class="input-medium" /><br />
+			Scadenza: <input type="date" name="fine" class="input-medium" /><br />
+			Luogo: <input type="text" name="luogo" class="input-medium" /><br />
+			Esaminatore: <a data-selettore="true" data-input="pConferma" data-autosubmit="false" class="btn btn-small"><i class="icon-edit"></i> <?= $me->nomeCompleto(); ?></a><br />
+
+			<br />
+
+			<textarea name="codicifiscali" cols="20" rows="15" placeholder="Codici fiscali (1 per riga)"></textarea><br />
+
+			<button type="submit" class="btn btn-success btn-block">
+				<i class="icon-plus"></i> Aggiungi
+			</button>
+		</form>
+	</div>
+
+	<div class="span2">
+		<h3><i class="icon-minus"></i> Rimuovi</h3>
+		<hr />
+
+		<form action="?p=admin.titolo.volontari.aggiungirimuovi" method="POST">
+			<input type="hidden" name="id" value="<?= $t->id; ?>" />
+
+			<textarea id="rimuovi" name="codicifiscali" cols="15" rows="22" style="font-size: smaller;" placeholder="Codici fiscali (1 per riga)"></textarea><br />
+
+			<button type="submit" class="btn btn-danger btn-block">
+				<i class="icon-minus"></i> Rimuovi
+			</button>
+		</form>
+	</div>
+
+</div>

--- a/inc/presidente.utente.visualizza.php
+++ b/inc/presidente.utente.visualizza.php
@@ -793,7 +793,11 @@ $do = DonazionePersonale::filtra([['volontario', $u]]);
           <td>
             <?php if ($titolo->tConferma) { ?>
             <abbr title="Confermato: <?php echo date('d-m-Y H:i', $titolo->tConferma); ?>">
-              <i class="icon-ok"></i>
+                <?php if ( $titolo->corso ) { ?>
+                    <i class="icon-asterisk"></i> 
+                <?php } else { ?>
+                    <i class="icon-ok"></i>
+                <?php } ?>
             </abbr>
             <?php } else { ?>
             <abbr title="Pendente">

--- a/inc/utente.titoli.php
+++ b/inc/utente.titoli.php
@@ -293,7 +293,14 @@ paginaPrivata();
                             <?php if ($titolo->tConferma) { ?>
                             <td>
                                 <abbr title="<?php echo date('d-m-Y H:i', $titolo->tConferma); ?>">
-                                    <i class="icon-ok"></i> Confermato
+
+                                    <?php if ( $titolo->corso ) { ?>
+                                        <i class="icon-asterisk"></i> Certificato<br />
+                                        <span style="font-size: smaller;">da <?= $titolo->pConferma()->nomeCompleto(); ?></span>
+                                    <?php } else { ?>
+                                        <i class="icon-ok"></i> Confermato
+                                    <?php } ?>
+                                    
                                 </abbr>
                             </td>    
                             <?php } else { ?>

--- a/upload/setup/gaia.sql
+++ b/upload/setup/gaia.sql
@@ -804,6 +804,7 @@ CREATE TABLE IF NOT EXISTS `titoliPersonali` (
   `fine` varchar(64) DEFAULT NULL,
   `luogo` varchar(64) DEFAULT NULL,
   `codice` varchar(64) DEFAULT NULL,
+  `corso` varchar(64) DEFAULT NULL,
   `tConferma` varchar(64) DEFAULT NULL,
   `pConferma` varchar(64) DEFAULT NULL,
   PRIMARY KEY (`id`)


### PR DESCRIPTION
Introduce i titoli certificati. Questi verranno marcati come "Certificati" nel Curriculum dei volontari. 

Tecnicamente, per marcare un titolo come certificato, e' necessario che venga riempito il campo `corso` con un qualunque valore ([non nullo o `== false`](http://php.net/manual/en/types.comparisons.php)), nel corrispettivo `TitoloPersonale`. Il campo dovrebbe contenere un codice identificativo del corso che ha permesso l'attribuzione del titolo. Ove non disponibile, per convenzione, associare un codice nel formato `X-[0-9]{5}` (es. `X-12345`, dove `12345` e' un numero casuale non gia' assegnato).

Gli amministratori (supporto di terzo livello), su ricezione di un elenco di volontari che hanno superato un corso ed hanno acquisito un determinato titolo, vanno su Admin > Titoli > *selezione titolo* > Gestione, inseriscono i dettagli del corso e certificano la qualifica.

- [x] @CroceRossaCatania/sviluppatori check
- [x] @CroceRossaCatania/supporto ack
- [x] SQL (aggiungere colonna `corso` come da `upload/setup/gaia.sql`)