### PR TITLE
niente quote per gli ordinari

### DIFF
--- a/assets/js/us.ordinario.nuovo.js
+++ b/assets/js/us.ordinario.nuovo.js
@@ -2,6 +2,5 @@ $(document).ready( function() {
  
 $("#inputDataNascita").datepicker();
 $("#inputDataIngresso").datepicker();
-$("#inputDataQuota").datepicker();
 
 });

--- a/inc/us.ordinario.nuovo.php
+++ b/inc/us.ordinario.nuovo.php
@@ -185,27 +185,7 @@ $t = Tesseramento::by('anno', date('Y'));
                     </a>
 
                 </div>
-            </div>
-            <br/>
-            <div class="row-fluid">            
-                <div class="span4 centrato">
-                    <label class="control-label" for="inputQuota" >Importo quota * </label>
-                </div>
-                <div class="span8 input-prepend">
-                    <span class="add-on">€</span>
-                    <input type="number" name="inputQuota" 
-                    id="inputQuota" step="0.01" min="<?php echo $t->ordinario ?>" 
-                    value="<?php echo $t->ordinario ?>" required />
-                </div>
-            </div>
-            <div class="row-fluid">            
-                <div class="span4 centrato">
-                    <label class="control-label" for="inputDataQuota" >Data versamento quota * </label>
-                </div>
-                <div class="span8">
-                    <input type="text" name="inputDataQuota" id="inputDataQuota" required />
-                </div>
-            </div>          
+            </div>         
             <hr />
         </div>
         <div class="modal-footer">


### PR DESCRIPTION
In attesa che il sistema di gestione soci e quote di gaia rispecchi i vari regolamenti, attualmente contrastanti, questo fix permettere di registrare i soci ordinari senza registrare la loro quota, allo scopo di poterli aggiungere ad un corso base e farli poi diventare soci del comitato. In questo modo è possibile gestire i corsi base senza che i comitato debbano registrare quote di soci ordinari incorrette.

Non ho potuto effettuare nessun test in quanto non dispongo di un db di test